### PR TITLE
Publishing the plugin locally is a more realistic way to test things.

### DIFF
--- a/test-using-included-build/src/main/kotlin/my-plugin.gradle.kts
+++ b/test-using-included-build/src/main/kotlin/my-plugin.gradle.kts
@@ -14,3 +14,4 @@
  */
 
 // nothing here. but this file has to exist to trigger the issue.
+println("my-plugin applied to ${rootProject.projectDir}")

--- a/test-using-included-build/src/test/kotlin/IncludedBuildTest.kt
+++ b/test-using-included-build/src/test/kotlin/IncludedBuildTest.kt
@@ -17,6 +17,7 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.nio.file.Path
 import java.nio.file.Paths
 
 
@@ -33,6 +34,10 @@ class IncludedBuildTest {
             """
                pluginManagement {
                    includeBuild("${Paths.get("..", "included-build").toAbsolutePath()}")
+                   
+                   repositories {
+                       maven("${Path.of(System.getProperty("pluginUnderTestMavenRepo")).toAbsolutePath()}")
+                   }
                }
 
                plugins {
@@ -43,7 +48,7 @@ class IncludedBuildTest {
 
         val build = GradleRunner.create()
             .withDebug(true)
-            .withPluginClasspath() // this is the key to reproducing the issue, it changes the classpath of the included build.
+            //.withPluginClasspath() // instead we use the locally published plugin and the test does not fail
             .withProjectDir(tempDir)
             .withArguments("build")
             .build()


### PR DESCRIPTION
This PR shows the workaround. 